### PR TITLE
do not lowercase Swift metadata values

### DIFF
--- a/openstack-operator/python/openstack_seeder.py
+++ b/openstack-operator/python/openstack_seeder.py
@@ -1285,7 +1285,7 @@ def seed_swift_containers(project, containers, conn):
             if 'metadata' in container:
                 for meta in container['metadata'].keys():
                     header = 'x-container-%s' % meta
-                    headers[header] = str(container['metadata'][meta]).lower()
+                    headers[header] = str(container['metadata'][meta])
             try:
                 # see if the container already exists
                 result = conn.head_container(container['name'])

--- a/openstack-seeder/python/openstack_seeder.py
+++ b/openstack-seeder/python/openstack_seeder.py
@@ -1285,7 +1285,7 @@ def seed_swift_containers(project, containers, conn):
             if 'metadata' in container:
                 for meta in container['metadata'].keys():
                     header = 'x-container-%s' % meta
-                    headers[header] = str(container['metadata'][meta]).lower()
+                    headers[header] = str(container['metadata'][meta])
             try:
                 # see if the container already exists
                 result = conn.head_container(container['name'])


### PR DESCRIPTION
This breaks X-Container-Meta-Temp-URL-Key containing uppercase characters.