### PR TITLE
[openstack-seeder] Multi-stage build for reduced build time and image-size

### DIFF
--- a/openstack-seeder/Dockerfile
+++ b/openstack-seeder/Dockerfile
@@ -1,4 +1,22 @@
-FROM ubuntu:xenial
+FROM python:2 as pybuild
+
+COPY python/setup.py /openstack-seeder/
+RUN mkdir /wheels && pip wheel -w /wheels /openstack-seeder/ && rm /wheels/openstack_seeder*
+
+FROM golang:1 as gobuild
+ARG NS=github.com/sapcc/kubernetes-operators/openstack-seeder
+RUN mkdir -p /go/src/$NS
+WORKDIR /go/src/$NS
+ADD vendor ./vendor
+ADD cmd ./cmd
+ADD pkg ./pkg
+ARG VERSION
+RUN go build\
+    -v -i -o /openstack-seeder \
+    -ldflags "-X github.com/sapcc/kubernetes-operators/openstack-seeder/pkg/seeder/controller.VERSION=${VERSION}"\
+    ./cmd
+
+FROM python:2-slim
 MAINTAINER Rudolf Vriend <rudolf.vriend@sap.com>
 
 ENV REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
@@ -18,15 +36,12 @@ RUN echo 'precedence ::ffff:0:0/96  100' >> /etc/gai.conf && \
 
 RUN curl -sLo /usr/local/bin/kubernetes-entrypoint https://github.wdf.sap.corp/d062284/k8s-entrypoint-build/releases/download/f52d105/kubernetes-entrypoint && \
     chmod +x /usr/local/bin/kubernetes-entrypoint
-
+COPY --from=pybuild /wheels /wheels
 WORKDIR /openstack-seeder
 COPY python/* /openstack-seeder/
-RUN apt-get update && \
-    apt-get dist-upgrade -y && \
-    apt-get install -y --no-install-recommends build-essential pkg-config git openssl libssl-dev libyaml-dev libffi-dev python python-setuptools python-dev && \
-    python setup.py install && \
-    apt-get purge -y --auto-remove build-essential pkg-config git python-dev libssl-dev libffi-dev libyaml-dev && \
+RUN pip install --no-cache-dir --no-compile --no-index --find-links /wheels -e /openstack-seeder && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /root/.cache
 
+COPY --from=gobuild /openstack-seeder /usr/local/bin
+
 WORKDIR /
-ADD bin/linux/openstack-seeder /usr/local/bin

--- a/openstack-seeder/Makefile
+++ b/openstack-seeder/Makefile
@@ -12,6 +12,7 @@ PACKAGES := $(shell find $(SRCDIRS) -type d)
 GOFILES  := $(addsuffix /*.go,$(PACKAGES))
 GOFILES  := $(wildcard $(GOFILES))
 
+BUILD_ARGS := --build-arg VERSION=$(VERSION)
 ifneq ($(http_proxy),)
 BUILD_ARGS+= --build-arg http_proxy=$(http_proxy) --build-arg https_proxy=$(https_proxy) --build-arg no_proxy=$(no_proxy)
 endif
@@ -23,7 +24,7 @@ all: bin/$(GOOS)/$(BINARY)
 bin/%/$(BINARY): $(GOFILES) Makefile
 	GOOS=$* GOARCH=amd64 go build $(GOFLAGS) -v -i -o bin/$*/$(BINARY) ./cmd
 
-build: bin/linux/$(BINARY)
+build:
 	docker build $(BUILD_ARGS) -t $(IMAGE):$(VERSION) .
 
 push: build


### PR DESCRIPTION
The dependend wheels are only changing when the setup.py changes, so we can make use of the cache here
Also it removes the build-dependencies from the resulting image, cutting down the image size substantially

Enclose the build into the dockerfile too, so it doesn't depend on the underlying OS
