### PR TITLE
Fix logging and handle services

### DIFF
--- a/disco/README.md
+++ b/disco/README.md
@@ -76,6 +76,35 @@ the operator would create the following CNAME in the configured zone in OpenStac
 +-----------------------+-------+----------------+
 ```
 
+Given the following service:
+
+```
+apiVersion: v1
+kind: Service
+metadata
+  annotations:
+    disco: "true"
+    disco/record: myhost.zone.tld.
+spec:
+  externalIPs:
+  - 1.2.3.4
+  loadBalancerIP: 1.2.3.4
+  ...
+status:
+  loadBalancer:
+    ingress:
+    - ip: 1.2.3.4
+```
+
+the operator would create the following A record in the configured zone in OpenStack Designate
+```
++-----------------------+-------+----------------+
+| name                  | type  | records        |
++------------------------------------------------+
+| myhost.zone.tld.      | A     | 1.2.3.4        |
++-----------------------+-------+----------------+
+```
+
 **Fine-tuning:**  
 
 The operator has to be configured with a default record.
@@ -106,6 +135,7 @@ Usage of disco:
       --config string               Path to operator config file (default "/etc/disco/disco.conf")
       --debug                       Enable debug logging
       --ingress-annotation string   Handle ingress with this annotation (default "disco")
+      --service-annotation string   Handle service with this annotation (default "disco")
       --kubeconfig string           Path to kubeconfig file with authorization and master location information
       --metric-port int             Metrics are exposed on this port (default 9091)
       --recheck-period int          RecheckPeriod[min] defines the base period after which configmaps are checked again (default 5)

--- a/disco/cmd/disco/main.go
+++ b/disco/cmd/disco/main.go
@@ -45,6 +45,7 @@ func init() {
 	pflag.StringVar(&options.KubeConfig, "kubeconfig", "", "Path to kubeconfig file with authorization and master location information")
 	pflag.StringVar(&options.ConfigPath, "config", "/etc/disco/disco.conf", "Path to operator config file")
 	pflag.StringVar(&options.IngressAnnotation, "ingress-annotation", "disco", "Handle ingress with this annotation")
+	pflag.StringVar(&options.ServiceAnnotation, "service-annotation", "disco", "Handle service with this annotation")
 	pflag.IntVar(&options.Threadiness, "threadiness", 1, "The operator threadiness")
 	pflag.StringVar(&options.MetricHost, "metric-host", "0.0.0.0", "Host to expose metrics on")
 	pflag.IntVar(&options.MetricPort, "metric-port", 9091, "Metrics are exposed on this port")

--- a/disco/pkg/config/options.go
+++ b/disco/pkg/config/options.go
@@ -35,6 +35,7 @@ type Options struct {
 	ZoneName,
 	EventComponent,
 	IngressAnnotation,
+	ServiceAnnotation,
 	Finalizer,
 	MetricHost string
 	Threadiness,
@@ -48,6 +49,7 @@ type Options struct {
 
 func (o *Options) applyDefaultsIfNotSet() {
 	o.IngressAnnotation = trimQuotesAndSpace(o.IngressAnnotation)
+	o.ServiceAnnotation = trimQuotesAndSpace(o.ServiceAnnotation)
 	o.ZoneName = trimQuotesAndSpace(o.ZoneName)
 	o.Record = trimQuotesAndSpace(o.Record)
 }

--- a/disco/pkg/disco/contants.go
+++ b/disco/pkg/disco/contants.go
@@ -23,7 +23,7 @@ const (
 	// discoRecordsetDescription is the default description for a recordset.
 	discoRecordsetDescription = "Managed by the DISCOperator."
 
-	// discoAnnotationRecord allows setting a different record than the default per ingress.
+	// discoAnnotationRecord allows setting a different record than the default per ingress or service.
 	discoAnnotationRecord = "record"
 
 	// discoAnnotationRecordType allows setting the record type. Must be CNAME, A, NS, SOA. Default: CNAME.

--- a/disco/pkg/disco/operator.go
+++ b/disco/pkg/disco/operator.go
@@ -326,7 +326,7 @@ func (disco *Operator) checkRecord(discoRecord *recordHelper, host string) error
 	defer func() {
 		if err != nil {
 			// Just emit the event here. The error is logged in he processNextWorkItem.
-			disco.k8sFramework.Eventf(discoRecord.object, v1.EventTypeNormal, updateEvent, fmt.Sprintf("create recordset on %s %s failed", discoRecord.getKind(), discoRecord.getKey()))
+			disco.k8sFramework.Eventf(discoRecord.object, v1.EventTypeNormal, updateEvent, "create recordset on %s %s failed", discoRecord.getKind(), discoRecord.getKey())
 		}
 	}()
 
@@ -365,16 +365,16 @@ func (disco *Operator) checkRecord(discoRecord *recordHelper, host string) error
 	if k8sutils.HasDeletionTimestamp(discoRecord.object) {
 		if recordsetID == "" {
 			disco.logger.LogInfo("would delete recordset but was unable to find its uid", "host", host, "zoneName", zone.Name)
-			disco.k8sFramework.Eventf(discoRecord.object, v1.EventTypeNormal, deleteEvent, fmt.Sprintf("delete recordset on ingress %s failed", discoRecord.getKey()))
+			disco.k8sFramework.Eventf(discoRecord.object, v1.EventTypeNormal, deleteEvent, "delete recordset on %s %s failed", discoRecord.getKind(), discoRecord.getKey())
 			return disco.k8sFramework.EnsureDiscoFinalizerRemoved(discoRecord.object)
 		}
 		if err := disco.dnsV2Client.deleteDesignateRecordset(host, recordsetID, zone.ID); err != nil {
 			metrics.RecordsetDeletionFailedCounter.With(labels).Inc()
 			disco.logger.LogError("failed to delete recordset", err)
-			disco.k8sFramework.Eventf(discoRecord.object, v1.EventTypeNormal, deleteEvent, fmt.Sprintf("delete recordset on ingress %s failed", discoRecord.getKey()))
+			disco.k8sFramework.Eventf(discoRecord.object, v1.EventTypeNormal, deleteEvent, "delete recordset on %s %s failed", discoRecord.getKind(), discoRecord.getKey())
 			return disco.k8sFramework.EnsureDiscoFinalizerRemoved(discoRecord.object)
 		}
-		disco.k8sFramework.Eventf(discoRecord.object, v1.EventTypeNormal, deleteEvent, fmt.Sprintf("deleted recordset on ingress %s successful", discoRecord.getKey()))
+		disco.k8sFramework.Eventf(discoRecord.object, v1.EventTypeNormal, deleteEvent, "deleted recordset on %s %s successful", discoRecord.getKind(), discoRecord.getKey())
 		metrics.RecordsetDeletionSuccessCounter.With(labels).Inc()
 		return disco.k8sFramework.EnsureDiscoFinalizerRemoved(discoRecord.object)
 	}
@@ -418,7 +418,7 @@ func (disco *Operator) checkRecord(discoRecord *recordHelper, host string) error
 
 	metrics.RecordsetCreationSuccessCounter.With(labels).Inc()
 	disco.logger.LogInfo("create recordset successful", "key", discoRecord.getKey(), "host", host, "record", record, "zone", ensureFQDN(zone.Name), "recordType", recordType)
-	disco.k8sFramework.Eventf(discoRecord.object, v1.EventTypeNormal, createEvent, fmt.Sprintf("create recordset on ingress %s successful", discoRecord.getKey()))
+	disco.k8sFramework.Eventf(discoRecord.object, v1.EventTypeNormal, createEvent, "create recordset on %s %s successful", discoRecord.getKind(), discoRecord.getKey())
 
 	return nil
 }

--- a/disco/pkg/disco/util.go
+++ b/disco/pkg/disco/util.go
@@ -136,14 +136,6 @@ func filterEmpty(sslice []string) []string {
 	return filteredSlice
 }
 
-func ingressKey(ing *v1beta1.Ingress) string {
-	key, err := keyFunc(ing)
-	if err != nil {
-		return ""
-	}
-	return key
-}
-
 // ensureFQDN ensures the recordset name ends with '.'
 func ensureFQDN(s string) string {
 	if !strings.HasSuffix(s, ".") {

--- a/disco/pkg/disco/util.go
+++ b/disco/pkg/disco/util.go
@@ -59,7 +59,14 @@ func (r *recordHelper) getKey() string {
 
 func (r *recordHelper) getKind() string {
 	objMeta, err := meta.TypeAccessor(r.object)
-	if err != nil {
+	if err != nil || objMeta.GetKind() == "" {
+		switch r.object.(type) {
+		case *v1beta1.Ingress:
+			return "ingress"
+		case *v1.Record:
+			return "record"
+		}
+
 		return ""
 	}
 	return strings.ToLower(objMeta.GetKind())

--- a/disco/pkg/disco/util.go
+++ b/disco/pkg/disco/util.go
@@ -22,6 +22,7 @@ package disco
 import (
 	"fmt"
 	"strings"
+	"unicode"
 
 	"github.com/gophercloud/gophercloud/openstack/dns/v2/recordsets"
 	"github.com/gophercloud/gophercloud/openstack/dns/v2/zones"
@@ -35,17 +36,21 @@ import (
 
 // recordHelper struct used to wrap ingress, service and discoRecord CRD.
 type recordHelper struct {
-	recordType,
-	record,
-	zoneName,
+	recordType  string
+	records     []string
+	zoneName    string
 	description string
-	object runtime.Object
+	object      runtime.Object
+}
+
+func splitFunc(c rune) bool {
+	return !unicode.IsLetter(c) && !unicode.IsNumber(c) && c != '.' && c != '_' && c != '-'
 }
 
 func newDefaultRecordHelper(record, zoneName string) *recordHelper {
 	return &recordHelper{
 		recordType:  RecordsetType.CNAME,
-		record:      record,
+		records:     strings.FieldsFunc(record, splitFunc),
 		zoneName:    zoneName,
 		description: discoRecordsetDescription,
 	}

--- a/disco/pkg/k8sutils/crd.go
+++ b/disco/pkg/k8sutils/crd.go
@@ -40,16 +40,16 @@ func NewDiscoRecordCRD() *extensionsobj.CustomResourceDefinition {
 	})
 	crd.Spec.AdditionalPrinterColumns = []extensionsobj.CustomResourceColumnDefinition{
 		{
-			Name: "record",
-			Type: "string",
+			Name:        "record",
+			Type:        "string",
 			Description: "The record",
-			JSONPath: ".spec.record",
+			JSONPath:    ".spec.record",
 		},
 		{
-			Name: "type",
-			Type: "string",
+			Name:        "type",
+			Type:        "string",
 			Description: "The type of the record",
-			JSONPath: ".spec.type",
+			JSONPath:    ".spec.type",
 		},
 	}
 	crd.Spec.Subresources = nil

--- a/disco/pkg/k8sutils/framework.go
+++ b/disco/pkg/k8sutils/framework.go
@@ -196,7 +196,7 @@ func (k8s *K8sFramework) AddDiscoCRDInformerEventHandler(addFunc, deleteFunc fun
 
 // Eventf emits an event via the event recorder.
 func (k8s *K8sFramework) Eventf(object runtime.Object, eventType, reason, messageFmt string, args ...interface{}) {
-	k8s.eventRecorder.Eventf(object, eventType, reason, messageFmt)
+	k8s.eventRecorder.Eventf(object, eventType, reason, messageFmt, args...)
 }
 
 // CreateDiscoRecordCRDAndWaitUntilReady creates the CRDs used by this operator and waits until they are ready or the operation times out.

--- a/disco/pkg/k8sutils/framework.go
+++ b/disco/pkg/k8sutils/framework.go
@@ -42,6 +42,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	apimachineryWatch "k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/informers/core/v1"
 	v1beta12 "k8s.io/client-go/informers/extensions/v1beta1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -68,6 +69,7 @@ type K8sFramework struct {
 	finalizer               string
 	discoCRDInformerFactory genCRDInformers.SharedInformerFactory
 	ingressInformer         cache.SharedIndexInformer
+	serviceInformer         cache.SharedIndexInformer
 	discoCRDInformer        cache.SharedIndexInformer
 }
 
@@ -124,6 +126,13 @@ func NewK8sFramework(options config.Options, logger log.Logger) (*K8sFramework, 
 		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
 	)
 
+	serviceInformer := v1.NewServiceInformer(
+		clientset,
+		apimetav1.NamespaceAll,
+		options.ResyncPeriod,
+		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+	)
+
 	informerFactory := genCRDInformers.NewSharedInformerFactory(crdClient, options.ResyncPeriod)
 	discoCRDInformer := informerFactory.Disco().V1().Records().Informer()
 
@@ -132,6 +141,7 @@ func NewK8sFramework(options config.Options, logger log.Logger) (*K8sFramework, 
 		kubeConfig:              config,
 		eventRecorder:           eventRecorder,
 		ingressInformer:         ingressInformer,
+		serviceInformer:         serviceInformer,
 		discoCRDInformer:        discoCRDInformer,
 		CRDclientset:            crdclientset,
 		DiscoCRDClientset:       discoCRDClient,
@@ -145,6 +155,7 @@ func (k8s *K8sFramework) Run(stopCh <-chan struct{}) {
 	go k8s.discoCRDInformerFactory.Start(stopCh)
 	go k8s.discoCRDInformer.Run(stopCh)
 	go k8s.ingressInformer.Run(stopCh)
+	go k8s.serviceInformer.Run(stopCh)
 }
 
 // WaitForCacheSync returns true if all caches have been synced.
@@ -153,6 +164,7 @@ func (k8s *K8sFramework) WaitForCacheSync(stopCh <-chan struct{}) bool {
 		stopCh,
 		k8s.discoCRDInformer.HasSynced,
 		k8s.ingressInformer.HasSynced,
+		k8s.serviceInformer.HasSynced,
 	)
 }
 
@@ -173,6 +185,25 @@ func (k8s *K8sFramework) GetIngressFromIndexerByKey(key string) (interface{}, bo
 // GetIngressInformerStore returns the ingress infromer store.
 func (k8s *K8sFramework) GetIngressInformerStore() cache.Store {
 	return k8s.ingressInformer.GetStore()
+}
+
+// AddServiceInformerEventHandler adds event handlers to the service informer.
+func (k8s *K8sFramework) AddServiceInformerEventHandler(addFunc, deleteFunc func(obj interface{}), updateFunc func(oldObj, newObj interface{})) {
+	k8s.serviceInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    addFunc,
+		UpdateFunc: updateFunc,
+		DeleteFunc: deleteFunc,
+	})
+}
+
+// GetServiceFromIndexerByKey returns the Service from the informer indexer by key.
+func (k8s *K8sFramework) GetServiceFromIndexerByKey(key string) (interface{}, bool, error) {
+	return k8s.serviceInformer.GetIndexer().GetByKey(key)
+}
+
+// GetServiceInformerStore returns the service infromer store.
+func (k8s *K8sFramework) GetServiceInformerStore() cache.Store {
+	return k8s.serviceInformer.GetStore()
 }
 
 // GetDiscoRecordFromIndexerByKey returns the Record from the informer indexer by key.
@@ -255,6 +286,37 @@ func (k8s *K8sFramework) UpdateIngressAndWait(oldIngress, newIngress *extensions
 	return k8s.waitForUpstreamIngress(updatedIngress, conditionFuncs...)
 }
 
+// GetService returns the service or an error.
+func (k8s *K8sFramework) GetService(namespace, name string) (*coreV1.Service, error) {
+	return k8s.CoreV1().Services(namespace).Get(name, metaV1.GetOptions{})
+}
+
+// UpdateServiceAndWait updates an existing Service and waits until the operation times out or is completed.
+func (k8s *K8sFramework) UpdateServiceAndWait(oldService, newService *coreV1.Service, conditionFuncs ...watch.ConditionFunc) error {
+	oldService, err := k8s.GetService(oldService.GetNamespace(), oldService.GetName())
+	if err != nil {
+		return err
+	}
+
+	// Nothing to update.
+	if !isServiceNeedsUpdate(oldService, newService) {
+		return nil
+	}
+
+	updatedService, err := k8s.CoreV1().Services(oldService.GetNamespace()).Update(newService)
+	if err != nil {
+		return err
+	}
+
+	k8s.logger.LogDebug("updating service", "key", fmt.Sprintf("%s/%s", oldService.GetNamespace(), oldService.GetName()))
+
+	if conditionFuncs == nil {
+		conditionFuncs = []watch.ConditionFunc{isServiceAddedOrModified}
+	}
+
+	return k8s.waitForUpstreamService(updatedService, conditionFuncs...)
+}
+
 // GetDiscoRecord returns the Record or an error.
 func (k8s *K8sFramework) GetDiscoRecord(namespace, name string) (*discov1.Record, error) {
 	return k8s.DiscoCRDClientset.Records(namespace).Get(name, metaV1.GetOptions{})
@@ -296,6 +358,8 @@ func (k8s *K8sFramework) UpdateObjectAndWait(oldObj, newObj runtime.Object, cond
 	switch oldObj.(type) {
 	case *extensionsv1beta1.Ingress:
 		return k8s.UpdateIngressAndWait(oldObj.(*extensionsv1beta1.Ingress), newObj.(*extensionsv1beta1.Ingress), conditionFuncs...)
+	case *coreV1.Service:
+		return k8s.UpdateServiceAndWait(oldObj.(*coreV1.Service), newObj.(*coreV1.Service), conditionFuncs...)
 	case *discov1.Record:
 		return k8s.UpdateDiscoRecordAndWait(oldObj.(*discov1.Record), newObj.(*discov1.Record), conditionFuncs...)
 	}
@@ -325,6 +389,11 @@ func (k8s *K8sFramework) EnsureDiscoFinalizerExists(obj runtime.Object) error {
 			ing.Finalizers = append(finalizers, k8s.finalizer)
 			newObj = ing
 
+		case *coreV1.Service:
+			svc := newObj.(*coreV1.Service)
+			svc.Finalizers = append(finalizers, k8s.finalizer)
+			newObj = svc
+
 		case *discov1.Record:
 			rec := newObj.(*discov1.Record)
 			rec.Finalizers = append(finalizers, k8s.finalizer)
@@ -344,7 +413,7 @@ func (k8s *K8sFramework) EnsureDiscoFinalizerExists(obj runtime.Object) error {
 					return false, apiErrors.NewNotFound(schema.GroupResource{Resource: obj.GetObjectKind().GroupVersionKind().Kind}, objMeta.GetName())
 				}
 				switch o := event.Object.(type) {
-				case *extensionsv1beta1.Ingress, *discov1.Record:
+				case *extensionsv1beta1.Ingress, *coreV1.Service, *discov1.Record:
 					return hasDiscoFinalizer(o, k8s.finalizer), nil
 				}
 				return false, nil
@@ -378,6 +447,11 @@ func (k8s *K8sFramework) EnsureDiscoFinalizerRemoved(obj runtime.Object) error {
 			ing.Finalizers = finalizers
 			newObj = ing
 
+		case *coreV1.Service:
+			svc := newObj.(*coreV1.Service)
+			svc.Finalizers = finalizers
+			newObj = svc
+
 		case *discov1.Record:
 			rec := newObj.(*discov1.Record)
 			rec.Finalizers = finalizers
@@ -397,7 +471,7 @@ func (k8s *K8sFramework) EnsureDiscoFinalizerRemoved(obj runtime.Object) error {
 					return false, apiErrors.NewNotFound(schema.GroupResource{Resource: obj.GetObjectKind().GroupVersionKind().Kind}, objMeta.GetName())
 				}
 				switch ing := event.Object.(type) {
-				case *extensionsv1beta1.Ingress, *discov1.Record:
+				case *extensionsv1beta1.Ingress, *coreV1.Service, *discov1.Record:
 					return !hasDiscoFinalizer(ing, k8s.finalizer), nil
 				}
 				return false, nil
@@ -421,6 +495,26 @@ func (k8s *K8sFramework) waitForUpstreamIngress(ingress *extensionsv1beta1.Ingre
 			},
 		},
 		ingress,
+		nil,
+		conditionFuncs...,
+	)
+	return err
+}
+
+// waitForUpstreamService watches the given Service and wait for max. t minutes until the given condition applies.
+func (k8s *K8sFramework) waitForUpstreamService(service *coreV1.Service, conditionFuncs ...watch.ConditionFunc) error {
+	ctx, _ := context.WithTimeout(context.TODO(), WaitTimeout)
+	_, err := watch.UntilWithSync(
+		ctx,
+		&cache.ListWatch{
+			ListFunc: func(options metaV1.ListOptions) (object runtime.Object, e error) {
+				return k8s.CoreV1().Services(service.GetNamespace()).List(metaV1.SingleObject(metaV1.ObjectMeta{Name: service.GetName()}))
+			},
+			WatchFunc: func(options metaV1.ListOptions) (i apimachineryWatch.Interface, e error) {
+				return k8s.CoreV1().Services(service.GetNamespace()).Watch(metaV1.SingleObject(metaV1.ObjectMeta{Name: service.GetName()}))
+			},
+		},
+		service,
 		nil,
 		conditionFuncs...,
 	)

--- a/disco/pkg/k8sutils/util.go
+++ b/disco/pkg/k8sutils/util.go
@@ -61,8 +61,6 @@ func isIngressAddedOrModified(event apimachineryWatch.Event) (bool, error) {
 		return false, apiErrors.NewNotFound(schema.GroupResource{Resource: "ingress"}, "")
 	case apimachineryWatch.Added, apimachineryWatch.Modified:
 		return true, nil
-	default:
-		return false, nil
 	}
 	return false, nil
 }
@@ -73,8 +71,6 @@ func isDiscoRecordAddedOrModified(event apimachineryWatch.Event) (bool, error) {
 		return false, apiErrors.NewNotFound(schema.GroupResource{Resource: "discoRecord"}, "")
 	case apimachineryWatch.Added, apimachineryWatch.Modified:
 		return true, nil
-	default:
-		return false, nil
 	}
 	return false, nil
 }
@@ -85,8 +81,6 @@ func isCRDAddedOrModified(event apimachineryWatch.Event) (bool, error) {
 		return false, apiErrors.NewNotFound(schema.GroupResource{Resource: "customresourcedefinition"}, "")
 	case apimachineryWatch.Added, apimachineryWatch.Modified:
 		return true, nil
-	default:
-		return false, nil
 	}
 	return false, nil
 }

--- a/disco/pkg/k8sutils/util.go
+++ b/disco/pkg/k8sutils/util.go
@@ -23,6 +23,7 @@ import (
 	"reflect"
 
 	v1 "github.com/sapcc/kubernetes-operators/disco/pkg/apis/disco/v1"
+	coreV1 "k8s.io/api/core/v1"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -48,6 +49,14 @@ func isIngressNeedsUpdate(old, new *extensionsv1beta1.Ingress) bool {
 	return false
 }
 
+func isServiceNeedsUpdate(old, new *coreV1.Service) bool {
+	// Service needs update if spec or annotations changed or deletionTimestamp was added.
+	if !reflect.DeepEqual(old.Spec, new.Spec) || !reflect.DeepEqual(old.GetAnnotations(), new.GetAnnotations()) || !reflect.DeepEqual(old.GetDeletionTimestamp(), new.GetDeletionTimestamp()) {
+		return true
+	}
+	return false
+}
+
 func isDiscoRecordNeedsUpdate(old, new *v1.Record) bool {
 	if !reflect.DeepEqual(old.Spec, new.Spec) || !reflect.DeepEqual(old.GetAnnotations(), new.GetAnnotations()) || !reflect.DeepEqual(old.GetDeletionTimestamp(), new.GetDeletionTimestamp()) {
 		return true
@@ -59,6 +68,16 @@ func isIngressAddedOrModified(event apimachineryWatch.Event) (bool, error) {
 	switch event.Type {
 	case apimachineryWatch.Deleted:
 		return false, apiErrors.NewNotFound(schema.GroupResource{Resource: "ingress"}, "")
+	case apimachineryWatch.Added, apimachineryWatch.Modified:
+		return true, nil
+	}
+	return false, nil
+}
+
+func isServiceAddedOrModified(event apimachineryWatch.Event) (bool, error) {
+	switch event.Type {
+	case apimachineryWatch.Deleted:
+		return false, apiErrors.NewNotFound(schema.GroupResource{Resource: "service"}, "")
 	case apimachineryWatch.Added, apimachineryWatch.Modified:
 		return true, nil
 	}

--- a/disco/pkg/log/log.go
+++ b/disco/pkg/log/log.go
@@ -20,6 +20,7 @@
 package log
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/go-kit/kit/log"
@@ -84,5 +85,5 @@ func (l *Logger) LogFatal(msg string, keyvals ...interface{}) {
 
 // LogEvent logs events.
 func (l *Logger) LogEvent(format string, obj ...interface{}) {
-	level.Debug(l.logger).Log(append([]interface{}{"event", format}, obj...)...)
+	level.Debug(l.logger).Log("event", fmt.Sprintf(format, obj...))
 }


### PR DESCRIPTION
This PR adds an ability to manage DNS records from the service spec's externalIPs, loadBalancerIP and status's `loadBalancer.ingress` IPs.