### PR TITLE
Seed flavor traits

### DIFF
--- a/openstack-seeder/python/openstack_seeder.py
+++ b/openstack-seeder/python/openstack_seeder.py
@@ -2002,7 +2002,7 @@ def seed_resource_class(resource_class, args, sess):
         logging.error("Failed to seed resource-class %s: %s" % (resource_class, e))
 
 
-def seed_flavor(flavor, args, sess, config):
+def seed_flavor(flavor, args, sess):
     global resource_classes
     logging.debug("seeding flavor %s" % flavor)
 
@@ -2416,7 +2416,7 @@ def seed_config(config, args, sess):
 
     if 'flavors' in config:
         for flavor in config['flavors']:
-            seed_flavor(flavor, args, sess, config)
+            seed_flavor(flavor, args, sess)
 
     # Run it after seed_flavor, as we collect resource_classes there
     if 'resource_classes' in config:

--- a/openstack-seeder/python/openstack_seeder.py
+++ b/openstack-seeder/python/openstack_seeder.py
@@ -2026,12 +2026,10 @@ def seed_flavor(flavor, args, sess):
             'id', 'name', 'ram', 'disk', 'vcpus', 'swap', 'rxtx_factor',
             'is_public', 'disabled', 'ephemeral'))
         if 'name' not in flavor or not flavor['name']:
-            logging.warn(
-                "skipping flavor '%s', since it has no name" % flavor)
+            logging.warn("skipping flavor '%s', since it has no name" % flavor)
             return
         if 'id' not in flavor or not flavor['id']:
-            logging.warn(
-                "skipping flavor '%s', since its id is missing" % flavor)
+            logging.warn("skipping flavor '%s', since its id is missing" % flavor)
             return
 
         # wtf, flavors has no update(): needs to be dropped and re-created instead
@@ -2043,16 +2041,11 @@ def seed_flavor(flavor, args, sess):
             # 'rename' some attributes, since api and internal representation differ
             flavor_cmp = flavor.copy()
             if 'is_public' in flavor_cmp:
-                flavor_cmp[
-                    'os-flavor-access:is_public'] = flavor_cmp.pop(
-                    'is_public')
+                flavor_cmp['os-flavor-access:is_public'] = flavor_cmp.pop('is_public')
             if 'disabled' in flavor_cmp:
-                flavor_cmp['OS-FLV-DISABLED:disabled'] = flavor_cmp.pop(
-                    'disabled')
+                flavor_cmp['OS-FLV-DISABLED:disabled'] = flavor_cmp.pop('disabled')
             if 'ephemeral' in flavor_cmp:
-                flavor_cmp[
-                    'OS-FLV-EXT-DATA:ephemeral'] = flavor_cmp.pop(
-                    'ephemeral')
+                flavor_cmp['OS-FLV-EXT-DATA:ephemeral'] = flavor_cmp.pop('ephemeral')
 
             # check for delta
             for attr in list(flavor_cmp.keys()):


### PR DESCRIPTION
We have started to use custom traits for flavors and hosts more. This led to the situation that after the flavors where seeded the trait was not yet existing in the region. This fails _any_ placement of a VM with a flavor that mentions a trait in the extra-specs, even if it only sets the trait as "forbidden".

Openstack-Placement cannot act on any trait spec if it does not know the trait and will fail all deployments with traited flavors, required or forbidden.

To fix this, collect any and all custom flavors specified in the flavor seed and create them. This works exactly like the seeding of custom resource classes mentioned in the flavors' extra-specs.

Note: Unlike the placement API request for a resource-class which needs API version 1.7 or higher (previous versions failed on an existing resource-class), the trait API endpoint never had this limitation. Thus the trait-seed API call does not pin the API version.

----

Includes two cleanup commits.

- [openstack-seeder] Remove "config" arg from seed_flavor()
- [openstack-seeder] Cleanup: Join short lines in seed_flavor()
- [openstack-seeder] Seed custom traits from flavors
