### PR TITLE
Fix flavor extra_specs seeding

### DIFF
--- a/openstack-seeder/python/openstack_seeder.py
+++ b/openstack-seeder/python/openstack_seeder.py
@@ -2104,7 +2104,7 @@ def check_seedable_flavors_and_resourceclasses_and_traits(flavors, sess, args):
     for flavor in flavors:
         extra_specs = None
         if 'extra_specs' in flavor:
-            extra_specs = flavor.pop('extra_specs', None)
+            extra_specs = flavor['extra_specs']
             if not isinstance(extra_specs, dict):
                 logging.warn("skipping flavor '{}', since it has invalid extra_specs"
                              .format(flavor))


### PR DESCRIPTION
In previous commits we added seeding flavors only if their traits are
assigned. We got those traits from the extra_specs. In this process, we
removed the extra_specs key from the flavor and thus, when the flavor
was deemed ready for seeding, we did not have any extra_specs for
seeding anymore.