### PR TITLE
[sentry] add DSN without transport but with verify_ssl=0

### DIFF
--- a/sentry/Makefile
+++ b/sentry/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.2.1
+VERSION=0.2.2
 LDFLAGS=-X github.com/sapcc/kubernetes-operators/sentry/pkg/operator.VERSION=$(VERSION)
 IMAGE   ?= sapcc/kube-sentry
 GOOS    ?= darwin

--- a/sentry/pkg/operator/operator.go
+++ b/sentry/pkg/operator/operator.go
@@ -173,10 +173,12 @@ func (op *Operator) handler(key *v1.SentryProject) error {
 			return fmt.Errorf("Failed to create client key for project %s: %s", project.Spec.Name, err)
 		}
 		secretData := map[string]string{
-			fmt.Sprintf("%s.DSN", project.Spec.Name):               clientKey.DSN.Secret,
-			fmt.Sprintf("%s.DSN.public", project.Spec.Name):        clientKey.DSN.Public,
-			fmt.Sprintf("%s.DSN.python", project.Spec.Name):        fmt.Sprintf("requests+%s?verify_ssl=0", clientKey.DSN.Secret),
-			fmt.Sprintf("%s.DSN.public.python", project.Spec.Name): fmt.Sprintf("requests+%s?verify_ssl=0", clientKey.DSN.Public),
+			fmt.Sprintf("%s.DSN", project.Spec.Name):                       clientKey.DSN.Secret,
+			fmt.Sprintf("%s.DSN.public", project.Spec.Name):                clientKey.DSN.Public,
+			fmt.Sprintf("%s.DSN.python", project.Spec.Name):                fmt.Sprintf("requests+%s?verify_ssl=0", clientKey.DSN.Secret),
+			fmt.Sprintf("%s.DSN.public.python", project.Spec.Name):         fmt.Sprintf("requests+%s?verify_ssl=0", clientKey.DSN.Public),
+			fmt.Sprintf("%s.DSN.no_ssl_verify", project.Spec.Name):         fmt.Sprintf("%s?verify_ssl=0", clientKey.DSN.Secret),
+			fmt.Sprintf("%s.DSN.public.no_ssl_verify", project.Spec.Name):  fmt.Sprintf("%s?verify_ssl=0", clientKey.DSN.Public),
 		}
 
 		secret, err := op.clientset.CoreV1().Secrets(project.Namespace).Get("sentry", metav1.GetOptions{})


### PR DESCRIPTION
inspired by 69e2d80faa7c4b534a4199699dcf2376daf7d79c

I'm not sure if the underscores in `no_ssl_verify` are allowed.


The reason I need this is to get rid of the ugly ENV append I did here https://github.com/sapcc/helm-charts/commit/c33ccb24640693951a2dff064828257602a9df6a