### PR TITLE
Add re-use fips for nodepools

### DIFF
--- a/kube-fip-controller/Dockerfile
+++ b/kube-fip-controller/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.3-alpine3.16 as builder
+FROM golang:1.19-alpine3.16 as builder
 WORKDIR /go/src/github.com/sapcc/kubernetes-operators/kube-fip-controller
 RUN apk add --no-cache make
 COPY . .

--- a/kube-fip-controller/Makefile
+++ b/kube-fip-controller/Makefile
@@ -1,8 +1,9 @@
 DATE    = $(shell date +%Y%m%d%H%M)
 IMAGE   ?= sapcc/kube-fip-controller
-VERSION = v$(DATE)
+VERSION = v$(DATE)-test
 GOOS    ?= $(shell go env | grep GOOS | cut -d'"' -f2)
 BINARY  := controller
+OPTS    ?=
 
 SRCDIRS  := cmd pkg
 PACKAGES := $(shell find $(SRCDIRS) -type d)
@@ -20,7 +21,7 @@ bin/%/$(BINARY): $(GOFILES) Makefile
 	GOOS=$* GOARCH=amd64 go build -ldflags '-X github.com/sapcc/kubernetes-operators/kube-fip-controller/cmd.BuildCommit=$(GIT_COMMIT) -X github.com/sapcc/kubernetes-operators/kube-fip-controller/cmd.BuildDate=$(BUILD_DATE)' -mod vendor -v -o bin/$*/$(BINARY) ./cmd/main.go && chmod +x bin/$*/$(BINARY)
 
 build:
-	docker build -t $(IMAGE):$(VERSION) .
+	docker build $(OPTS) -t $(IMAGE):$(VERSION) .
 
 static-check:
 	@if s="$$(gofmt -s -l *.go pkg 2>/dev/null)"                            && test -n "$$s"; then printf ' => %s\n%s\n' gofmt  "$$s"; false; fi

--- a/kube-fip-controller/pkg/controller/controller.go
+++ b/kube-fip-controller/pkg/controller/controller.go
@@ -50,6 +50,12 @@ const (
 
 	//labelFloatingSubnetName controls which floating subnet is used for the FIP.
 	labelFloatingSubnetName = "kube-fip-controller.ccloud.sap.com/floating-subnet-name"
+
+	// labelNodepoolName label used to identify nodepools
+	labelNodepoolName = "ccloud.sap.com/nodepool"
+
+	// labelReuseFIPs indicates if FIPs should be re-used for a certain nodepool
+	labelReuseFIPs = "kube-fip-controller.ccloud.sap.com/reuse-fips"
 )
 
 // Controller ...
@@ -207,7 +213,17 @@ func (c *Controller) syncHandler(key string) error {
 		return err
 	}
 
-	fip, err := c.osFramework.GetOrCreateFloatingIP(floatingIP, floatingNetworkID, floatingSubnetID, server.TenantID)
+	nodepool := ""
+	if val, ok := getLabelValue(node, labelNodepoolName); ok {
+		nodepool = val
+	}
+
+	reuseFIPs := false
+	if val, ok := getLabelValue(node, labelReuseFIPs); ok {
+		reuseFIPs = (val == "true")
+	}
+
+	fip, err := c.osFramework.GetOrCreateFloatingIP(floatingIP, floatingNetworkID, floatingSubnetID, server.TenantID, nodepool, reuseFIPs)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR adds a label `kube-fip-controller.ccloud.sap.com/reuse-fips` to nodes and a description to allocated FIPs. This allows a re-use of FIPs for a certain nodepool when a node is terminated.