### PR TITLE
Allow required flavor props to be zero-valued

### DIFF
--- a/openstack-seeder/pkg/apis/seeder/v1/types.go
+++ b/openstack-seeder/pkg/apis/seeder/v1/types.go
@@ -273,9 +273,9 @@ type GroupSpec struct {
 type FlavorSpec struct {
 	Name       string            `json:"name" yaml:"name"` // flavor name
 	Id         string            `json:"id,omitempty" yaml:"id,omitempty"`
-	Ram        int               `json:"ram,omitempty" yaml:"ram,omitempty"`
-	Disk       int               `json:"disk,omitempty" yaml:"disk,omitempty"`
-	Vcpus      int               `json:"vcpus,omitempty" yaml:"vcpus,omitempty"`
+	Ram        int               `json:"ram" yaml:"ram"`
+	Disk       int               `json:"disk" yaml:"disk"`
+	Vcpus      int               `json:"vcpus" yaml:"vcpus"`
 	Swap       int               `json:"swap,omitempty" yaml:"swap,omitempty"`
 	RxTxfactor float32           `json:"rxtxfactor,omitempty" yaml:"rxtxfactor,omitempty"`
 	IsPublic   *bool             `json:"is_public,omitempty" yaml:"is_public,omitempty"`


### PR DESCRIPTION
Trying to seed a flavor with 0 disk size fails because the 0-value get's pruned from the flavor spec.

According to https://pkg.go.dev/encoding/json#Marshal the "omitempty" option in the struct definition is to blame for this. Remove it for some fields that are required for a flavor: RAM, Disk & vCPUs.

While it's hard to conceive of a useful flavor without either RAM or CPUs, it might be required for testing -- just like the testing flavor with no disk size that just failed.
