### PR TITLE
openstack-seeder: support selecting or ignoring multiple namespaces

### DIFF
--- a/openstack-seeder/cmd/main.go
+++ b/openstack-seeder/cmd/main.go
@@ -49,8 +49,8 @@ func main() {
 	pflag.StringVar(&options.KubeConfig, "kubeconfig", "", "Path to kubeconfig file with authorization and master location information.")
 	pflag.BoolVar(&options.DryRun, "dry-run", false, "Only pretend to seed.")
 	pflag.StringVar(&options.InterfaceType, "interface", "internal", "Openstack service interface type to use.")
-	pflag.StringVar(&options.IgnoreNamespace, "ignorenamespace", "", "Ignore seeds from a certain k8s Namespace.")
-	pflag.StringVar(&options.OnlyNamespace, "onlynamespace", "", "Only apply seeds from a certain k8s Namespace.")
+	pflag.StringArrayVar(&options.IgnoreNamespaces, "ignorenamespace", nil, "Ignore seeds from a certain k8s Namespace (can be given multiple times to ignore multiple namespaces).")
+	pflag.StringArrayVar(&options.OnlyNamespaces, "onlynamespace", nil, "Only apply seeds from a certain k8s Namespace (can be given multiple times to watch multiple namespaces).")
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.Parse()
 


### PR DESCRIPTION
The implementation is backwards-compatible with existing invocations.

My intention here is that I have been asked to deploy Limes for the `global` deployment. I will not put my deployment into `monsoon3global` because Limes expects to be deployed into its own namespace, so I want to reconfigure the global seeder to also look at namespace `limes-global`.