### PR TITLE
openstack-seeder: honor IgnoreNamespaces and OnlyNamespaces in seed dependencies

### DIFF
--- a/openstack-seeder/pkg/seeder/controller/controller.go
+++ b/openstack-seeder/pkg/seeder/controller/controller.go
@@ -421,6 +421,15 @@ func (c *Controller) resolveSeedDependencies(result *seederv1.OpenstackSeed, see
 			if namespace == "" {
 				namespace = seed.ObjectMeta.Namespace
 			}
+			if slices.Contains(c.Options.IgnoreNamespaces, namespace) {
+				return fmt.Errorf("refusing to resolve dependency '%s/%s' because its namespace is out of scope for this seeder", namespace, name)
+			}
+			if len(c.Options.OnlyNamespaces) > 0 {
+				if !slices.Contains(c.Options.OnlyNamespaces, namespace) {
+					return fmt.Errorf("refusing to resolve dependency '%s/%s' because its namespace is not in scope for this seeder", namespace, name)
+				}
+			}
+
 			spec, err = c.openstackseedsLister.OpenstackSeeds(namespace).Get(name)
 			if err != nil {
 				msg := fmt.Errorf("dependency '%s/%s' of '%s/%s' not found", namespace, name, seed.ObjectMeta.Namespace, seed.ObjectMeta.Name)


### PR DESCRIPTION
This bug caused major wreckage in the global-qa region when I accidentally pulled in non-global seeds as dependencies.