### PR TITLE
[Sentry] Remove Python DSN from secret data since its deprecated in S…

### DIFF
--- a/sentry/pkg/operator/operator.go
+++ b/sentry/pkg/operator/operator.go
@@ -177,7 +177,6 @@ func (op *Operator) handler(key *v1.SentryProject) error {
 		secretData := map[string]string{
 			fmt.Sprintf("%s.DSN", project.Spec.Name):               clientKey.DSN.Secret,
 			fmt.Sprintf("%s.DSN.public", project.Spec.Name):        clientKey.DSN.Public,
-			fmt.Sprintf("%s.DSN.python", project.Spec.Name):        fmt.Sprintf("requests+%s?verify_ssl=0", clientKey.DSN.Secret),
 			fmt.Sprintf("%s.DSN.public.python", project.Spec.Name): fmt.Sprintf("requests+%s?verify_ssl=0", clientKey.DSN.Public),
 		}
 


### PR DESCRIPTION
…entry v23

Removed the creation of a specific DSN for Python requests.