### PR TITLE
openstack-seeder: Allow seeding traits in the Go wrapper

### DIFF
--- a/openstack-seeder/pkg/apis/seeder/v1/types.go
+++ b/openstack-seeder/pkg/apis/seeder/v1/types.go
@@ -59,6 +59,8 @@ type OpenstackSeedSpec struct {
 	Regions []RegionSpec `json:"regions,omitempty" yaml:"regions,omitempty"`
 	// list keystone services and their endpoints
 	Services []ServiceSpec `json:"services,omitempty" yaml:"services,omitempty"`
+	// list of traits
+	Traits []string `json:"traits,omitempty" yaml:"traits,omitempty"`
 	// list of nova flavors
 	Flavors []FlavorSpec `json:"flavors,omitempty" yaml:"flavors,omitempty"`
 	// list of Manila share types

--- a/openstack-seeder/python/openstack_seeder.py
+++ b/openstack-seeder/python/openstack_seeder.py
@@ -2636,6 +2636,7 @@ def seed_config(config, args, sess):
 
     if 'traits' in config:
         traits.update(config['traits'])
+        traits -= _get_available_traits(sess, args)
 
     for trait in traits:
         logging.info("seeding trait {}".format(trait))


### PR DESCRIPTION
The python part can already handle traits, but the Go wrapper didn't pass it on
through.
